### PR TITLE
Resolve permission initialize at android SDK 33 higher

### DIFF
--- a/android/src/main/kotlin/app/sks/client/drago_usb_printer/tools/UsbDeviceHelper.kt
+++ b/android/src/main/kotlin/app/sks/client/drago_usb_printer/tools/UsbDeviceHelper.kt
@@ -27,7 +27,12 @@ class UsbDeviceHelper private constructor() {
 
     fun init(context: Context) {
         this.mContext = context
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        if (Build.VERSION.SDK_INT >= 33){
+            val intent: Intent = Intent(UsbDeviceReceiver.Config.ACTION_USB_PERMISSION)
+            intent.setPackage(mContext.packageName)
+            mPermissionIntent =
+                PendingIntent.getActivity(context, 0,  intent, PendingIntent.FLAG_MUTABLE)
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             mPermissionIntent =
                 PendingIntent.getActivity(context, 0,  Intent(UsbDeviceReceiver.Config.ACTION_USB_PERMISSION), PendingIntent.FLAG_MUTABLE)
         } else {


### PR DESCRIPTION
Resolve permission initialize at android SDK 33 higher version.
At follow the Google Android SDK 33 update note, Android restricts apps from sending implicit intents to internal app components.
We should be to launch the non-exposed activity, must be an explicit intent instead.
relative issue [https://github.com/selvam920/drago_usb_printer/issues/3](https://github.com/selvam920/drago_usb_printer/issues/3)
